### PR TITLE
[SC-73627] Update authtools to support Django 4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,160 @@
-*.pyc
-*.egg-info/
-docs/_build/
-tests/sqlite_database
-tests/.coverage
-tests/htmlcov/
-dist/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
 build/
-.tox
-/django.tar.gz
-.idea/
-.DS_Store
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 CHANGES
 =======
 
-2.0.1
+3.0.0
 ------------------
 
 - Add support for Django 4.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 CHANGES
 =======
 
-2.0.0
+2.0.1
 ------------------
 
-- Add support for Django 3.0
+- Add support for Django 4.2
 
 
 1.7.0 (2019-06-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 CHANGES
 =======
 
-3.0.0
+2.0.0
 ------------------
 
 - Add support for Django 4.2

--- a/authtools/views.py
+++ b/authtools/views.py
@@ -10,10 +10,7 @@ from django.contrib.auth import (
     get_user_model, update_session_auth_hash,
     REDIRECT_FIELD_NAME, login as auth_login
 )
-from django.contrib.auth.views import (
-    RedirectURLMixin,
-    INTERNAL_RESET_SESSION_TOKEN
-)
+from django.contrib.auth.views import INTERNAL_RESET_SESSION_TOKEN
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import (
     SetPasswordForm, PasswordChangeForm, PasswordResetForm
@@ -27,7 +24,7 @@ from django.contrib.sites.shortcuts import get_current_site
 
 from django.shortcuts import redirect, resolve_url
 from django.utils.functional import lazy
-from django.utils.http import url_has_allowed_host_and_scheme, urlsafe_base64_decode
+from django.utils.http import urlsafe_base64_decode
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters
@@ -35,6 +32,18 @@ from django.views.generic import FormView, TemplateView, RedirectView
 from django import VERSION as DJANGO_VERSION
 
 from .forms import AuthenticationForm
+
+try:
+    from django.contrib.auth.views import RedirectURLMixin
+except ImportError:  # <= Django 3.2
+    from django.contrib.auth.views import (
+        SuccessURLAllowedHostsMixin as RedirectURLMixin
+    )
+
+try:
+    from django.utils.http import url_has_allowed_host_and_scheme
+except ImportError:  # <= Django 3.2
+    from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
 
 User = get_user_model()
 

--- a/authtools/views.py
+++ b/authtools/views.py
@@ -11,7 +11,7 @@ from django.contrib.auth import (
     REDIRECT_FIELD_NAME, login as auth_login
 )
 from django.contrib.auth.views import (
-    SuccessURLAllowedHostsMixin,
+    RedirectURLMixin,
     INTERNAL_RESET_SESSION_TOKEN
 )
 from django.contrib.auth.decorators import login_required
@@ -27,7 +27,7 @@ from django.contrib.sites.shortcuts import get_current_site
 
 from django.shortcuts import redirect, resolve_url
 from django.utils.functional import lazy
-from django.utils.http import is_safe_url, urlsafe_base64_decode
+from django.utils.http import url_has_allowed_host_and_scheme, urlsafe_base64_decode
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters
@@ -74,7 +74,7 @@ class WithNextUrlMixin(object):
         except AttributeError:
             pass
 
-        url_is_safe = is_safe_url(
+        url_is_safe = url_has_allowed_host_and_scheme(
             redirect_to,
             allowed_hosts=allowed_hosts,
             require_https=self.request.is_secure()
@@ -136,7 +136,7 @@ class AuthDecoratorsMixin(NeverCacheMixin, CsrfProtectMixin, SensitivePostParame
     pass
 
 
-class LoginView(AuthDecoratorsMixin, SuccessURLAllowedHostsMixin,
+class LoginView(AuthDecoratorsMixin, RedirectURLMixin,
                 WithCurrentSiteMixin, WithNextUrlMixin, FormView):
     form_class = AuthenticationForm
     authentication_form = None
@@ -183,7 +183,7 @@ class LoginView(AuthDecoratorsMixin, SuccessURLAllowedHostsMixin,
         return kwargs
 
 
-class LogoutView(NeverCacheMixin, SuccessURLAllowedHostsMixin, WithCurrentSiteMixin,
+class LogoutView(NeverCacheMixin, RedirectURLMixin, WithCurrentSiteMixin,
                  WithNextUrlMixin, TemplateView,
                  RedirectView):
     template_name = 'registration/logged_out.html'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ coverage
 Sphinx
 zest.releaser[recommended]
 Django>=1.11
+django-upgrade==1.16.0
 -e .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,4 @@ coverage
 Sphinx
 zest.releaser[recommended]
 Django>=1.11
-django-upgrade==1.16.0
 -e .


### PR DESCRIPTION
[sc-73627](https://app.shortcut.com/wellthy/story/73627/update-authtools-package-fork)

## Overview
Upgrade the package to support Django 4.2. 

## Test Procedure
1. On `integration`, edit the `prod/requirements.txt` to change the `django-authtools` version to point to this PR's branch.
```
git+https://github.com/Wellthy/django-authtools.git@eyob_sc-73627
```
2. Rebuild your backend container and test authentication flows. 